### PR TITLE
feat: use internal assetId returned in the play response for analytics

### DIFF
--- a/src/main/java/com/redbeemedia/enigma/core/player/DefaultPlaybackStartAction.java
+++ b/src/main/java/com/redbeemedia/enigma/core/player/DefaultPlaybackStartAction.java
@@ -242,6 +242,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
                 try{
                 String requestId = jsonObject.optString("requestId");
                 String playToken = jsonObject.optString("playToken");
+                String assetId = jsonObject.optString("assetId");
                 JSONArray formats = jsonObject.getJSONArray("formats");
                 JSONArray spritesJson = jsonObject.optJSONArray("sprites");
                 boolean audioOnly = jsonObject.optBoolean("audioOnly",false);
@@ -272,7 +273,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
                         cdnProvider = cdnObject.optString("provider", "");
                     }
 
-                    IPlaybackSessionInfo playbackSessionInfo = playerConnector.getPlaybackSessionInfo(manifestUrl, cdnProvider, playbackSessionId);
+                    IPlaybackSessionInfo playbackSessionInfo = playerConnector.getPlaybackSessionInfo(assetId, manifestUrl, cdnProvider, playbackSessionId);
                     final JSONObject adsInfoJson = jsonObject.optJSONObject("ads");
                     final ExposureAdMetadata adsInfo = new ExposureAdMetadata(
                             adsInfoJson,
@@ -521,7 +522,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
     @Override
     public void startUsingDownloadData(Object downloadData) {
         try {
-            IPlaybackSessionInfo playbackSessionInfo = playerConnector.getPlaybackSessionInfo("mockManifest.mpd",null, null);
+            IPlaybackSessionInfo playbackSessionInfo = playerConnector.getPlaybackSessionInfo(null, "mockManifest.mpd", null, null);
             IContractRestrictions contractRestrictions = new EmptyContractRestrictions();
             IInternalPlaybackSession playbackSession = newPlaybackSession(new InternalPlaybackSession.ConstructorArgs(
                     new DownloadStreamInfo(),
@@ -564,7 +565,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
             return;
         }
 
-        IPlaybackSessionInfo playbackSessionInfo = playerConnector.getPlaybackSessionInfo(url.toString(),null, null);
+        IPlaybackSessionInfo playbackSessionInfo = playerConnector.getPlaybackSessionInfo(null, url.toString(), null, null);
         IInternalPlaybackSession playbackSession = newPlaybackSession(new InternalPlaybackSession.ConstructorArgs(
                 new UrlPlayableStreamInfo(),
                 null,

--- a/src/main/java/com/redbeemedia/enigma/core/player/EnigmaPlayer.java
+++ b/src/main/java/com/redbeemedia/enigma/core/player/EnigmaPlayer.java
@@ -366,12 +366,19 @@ public class EnigmaPlayer implements IEnigmaPlayer {
             }
 
             @Override
-            public IPlaybackSessionInfo getPlaybackSessionInfo(String manifestUrl, String cdnProvider, String playbackSessionId) {
+            public IPlaybackSessionInfo getPlaybackSessionInfo(String assetId, String manifestUrl, String cdnProvider, String playbackSessionId) {
                 IPlaybackTechnologyIdentifier technologyIdentifier = environment.playerImplementationInternals.getTechnologyIdentifier();
-                String assetId = "N/A";
-                IPlayable playable = playRequest.getPlayable();
-                if(playable instanceof IAssetPlayable) {
-                    assetId = ((IAssetPlayable) playable).getAssetId();
+                if (assetId == null || assetId.isEmpty())
+                {
+                    IPlayable playable = playRequest.getPlayable();
+                    if (playable instanceof IAssetPlayable)
+                    {
+                        assetId = ((IAssetPlayable) playable).getAssetId();
+                    }
+                    else
+                    {
+                        assetId = "N/A";
+                    }
                 }
                 return new EnigmaPlayer.PlaybackSessionInfo(playRequest.getPlayable(), assetId, manifestUrl, technologyIdentifier, playRequest.getPlaybackProperties(), cdnProvider, playbackSessionId);
             }

--- a/src/main/java/com/redbeemedia/enigma/core/player/IPlaybackStartAction.java
+++ b/src/main/java/com/redbeemedia/enigma/core/player/IPlaybackStartAction.java
@@ -22,7 +22,7 @@ import org.json.JSONObject;
     interface IEnigmaPlayerCallbacks {
         void setStateIfCurrentStartAction(IPlaybackStartAction action, EnigmaPlayerState state);
         void deliverPlaybackSession(IInternalPlaybackSession internalPlaybackSession);
-        IPlaybackSessionInfo getPlaybackSessionInfo(String manifestUrl, String cdnProvider, String playbackSessionId);
+        IPlaybackSessionInfo getPlaybackSessionInfo(String assetId, String manifestUrl, String cdnProvider, String playbackSessionId);
 
         JSONObject getUsableMediaFormat(JSONArray formats) throws JSONException;
     }


### PR DESCRIPTION
@iamramanjot , can you please check that pull request. This is to solve https://tools.cloud.ebms.ericsson.net/jira/browse/EMP-18707